### PR TITLE
Extract response 01

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,11 +15,11 @@ elif [ x"${COMPILER}" = "xwatcom" ] ; then
   export CFLAGS="-bt=DOS -bcl=DOS -ms -lr -fe="
 
 elif [ x"${COMPILER}" = "xwatcom-emu" ] ; then
-  dosemu -td -K . -E "build.bat watcom"
+  dosemu -q -td -K . -E "build.bat watcom"
   exit $?
 
 elif [ x"${COMPILER}" = "xtcc-emu" ] ; then
-  dosemu -td -K . -E "build.bat tcc"
+  dosemu -q -td -K . -E "build.bat tcc"
   exit $?
 
 else

--- a/kitten.c
+++ b/kitten.c
@@ -578,3 +578,38 @@ int get_line (int file, char *orig_str, int size)
 
 }
 
+/*
+ * input
+ *   s          : input string to be parsed
+ *   delimiters : start, intermediate and end
+ *   responses  : output buffer (has to be long enough for num chars)
+ *   num        : required number of responses
+ *
+ * return
+ *   0 on failure
+ *   1 on success
+ */
+int kitten_extract_response(const char *s, const char *delimiters,
+                            char *responses, int num) {
+  int slen = strlen(s);
+  const char *p, *q;
+  int i;
+
+  /* Response parsing requires substring usually of the form '(%c/%c)' */
+  p = strchr(s, delimiters[0]);
+  if (!p)
+    return 0;
+
+  /* Each response requires letter followed by a delimiter e.g. 'Y/' or 'N)' */
+  if (p + 1 - s > slen - 2 * num)
+    return 0;
+
+  for (i = 0; i < num; i++) {
+    q = p + 2 + i * 2;
+    if (*q != delimiters[1] && *q != delimiters[2])
+      return 0;
+    responses[i] = *(p + 1 + i * 2);
+  }
+
+  return 1;
+}

--- a/kitten.c
+++ b/kitten.c
@@ -129,7 +129,7 @@ void dos_close(int file)
  * On failure, catgets() returns the value 'message'.
  */
 
-char * kittengets(int setnum, int msgnum, char * message)
+const char *kittengets(int setnum, int msgnum, const char *message)
 {
 
   int i = 0;

--- a/kitten.h
+++ b/kitten.h
@@ -46,7 +46,7 @@ typedef int nl_catd;
 #define catclose(catalog)  kittenclose()
 #endif
 
-char *  kittengets( int set_number, int message_number,char *message);
+const char *kittengets(int setnum, int msgnum, const char *message);
 nl_catd kittenopen(char *name);
 void    kittenclose (void);
 

--- a/kitten.h
+++ b/kitten.h
@@ -52,6 +52,9 @@ void    kittenclose (void);
 
 int get_line (int file, char *buffer, int size);
 
+int kitten_extract_response(const char *s, const char *delimiters,
+                            char *responses, int num);
+
 #if defined(__TURBOC__)
 int dos_open(char *filename, int mode);
 #define open(filename,mode) dos_open(filename,mode)

--- a/test/nls/test.es
+++ b/test/nls/test.es
@@ -6,3 +6,4 @@
 1.1:Quiero leer el mensaje
 1.2:Usted puede traer un mensaje para ella
 2.0:Ella no tiene ese mensaje
+3.0:De verdad borrar este mensaje (S/N)? 

--- a/test/test.c
+++ b/test/test.c
@@ -10,11 +10,17 @@
 #define MSG3 "Look in the second class for the second message"
 #define RSP3 "Quiero leer el mensaje"
 
+// Please excuse the lack of an opening question mark on Spanish translation
+#define MSG4 "Really delete this message (Y/N)? "
+#define RSP4 "De verdad borrar este mensaje (S/N)? "
+#define KEY4 "SN"
+
 
 int main(void) {
 
   nl_catd cat;
-  char *m;
+  const char *m;
+  char tmpstr[10];
 
   putenv("NLSPATH=test\\nls");
   putenv("LANG=es");
@@ -40,6 +46,33 @@ int main(void) {
   }
   if (strcmp(RSP3, m) != 0) {
     puts("FAIL: MSG3 was not replaced with correct Spanish");
+    return 1;
+  }
+
+  m = catgets(cat, 3, 0, MSG4);
+  if (strcmp(MSG4, m) == 0) {
+    puts("FAIL: MSG4 was not replaced");
+    return 1;
+  }
+  if (strcmp(RSP4, m) != 0) {
+    puts("FAIL: MSG4 was not replaced with correct Spanish");
+    return 1;
+  }
+  if (!kitten_extract_response(m, "(/)", tmpstr, 2)) {
+    puts("FAIL: RSP4 was not parsed");
+    return 1;
+  }
+  if (tmpstr[0] != 'S' || tmpstr[1] != 'N') {
+    puts("FAIL: RSP4 was not parsed correctly");
+    return 1;
+  }
+
+  if (!kitten_extract_response("Choose [A:B:C:D]", "[:]", tmpstr, 4)) {
+    puts("FAIL: \"Choose [A:B:C:D]\" was not parsed");
+    return 1;
+  }
+  if (tmpstr[0] != 'A' || tmpstr[1] != 'B' || tmpstr[2] != 'C' || tmpstr[3] != 'D') {
+    puts("FAIL: \"Choose [A:B:C:D]\" was not parsed correctly");
     return 1;
   }
 


### PR DESCRIPTION
Adds a new function to kitten to extract the response keys from a string when given a set of delimiters.
So
- input "Do you want to exit (Y/N)? ", delimiters "(/)", output is "YN"
- input "Choose [A:B:C:D]", delimiters "[:]", output is "ABCD"

Assuming this is merged I'll be adding a PR to `label` to deal with this ticket https://github.com/FDOS/label/issues/11